### PR TITLE
Replaces syntax to be compatible with vanilla node.

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -5,7 +5,8 @@ var React     = require('react');
 var Router    = require('react-router');
 var mixin     = require('./mixin');
 
-var { Route, RouteHandler } = Router;
+var Route = Router.Route;
+var RouteHandler = Router.RouteHandler;
 
 var Resolver = function(context) {
   this.promises = {};
@@ -28,21 +29,19 @@ Resolver.prototype.route = function(routes) {
     },
 
     render: function() {
-      return <RouteHandler />;
+      return React.createElement(RouteHandler);
     }
   });
 
-  return (
-    <Route handler={ResolverContext}>
-      {routes}
-    </Route>
-  );
+  return React.createElement(Route, {handler: ResolverContext}, routes);
 };
 
 Resolver.prototype.resolve = function(element) {
   React.renderToStaticMarkup(element);
 
-  var pending = _.any(this.promises, (promise) => promise.isPending());
+  var pending = _.any(this.promises, function (promise) {
+    return promise.isPending();
+  });
 
   // Because the first render is hidden, a minimum of 1 resolution is required
   if (pending || !this.renders++) {
@@ -55,7 +54,7 @@ Resolver.prototype.resolve = function(element) {
 };
 
 Resolver.prototype.handle = function(Component) {
-  return this.resolve(<Component />);
+  return this.resolve(React.createElement(Component));
 };
 
 module.exports = Resolver;


### PR DESCRIPTION
Thank you for this library. When trying it out I noticed that I couldn't use it without compiling JSX etc. 

Since I don't use webpack for the nodejs part, I replaced the JSX, destruct assignment and arrow functions.
