### PR TITLE
Init documentation for the third argument for `Resolve.render`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ import { Resolver } from "react-resolver";
 Resolver.render(<Users />, document.getElementById("app"));
 ```
 
+You may pass in a `Resolver` instance as the third argument to `Resolver.render`.
+
+```js
+var resolver = new Resolver();
+Resolve.render(<Users />, document.getElementById("app"), resolver);
+```
+
+The `Resolver` instance exposes a few methods.
+
+#### `await`(`<array> promises = []`)
+
+Returns a promise after all promises (the resolves and the provided `promises`) have been *resolved*.
 
 ### Server
 


### PR DESCRIPTION
I've been checking the code for a while now, and this seems to undocumented. I'm not sure how to document the remaining methods being exposed by the `Resolver` class, so..