### PR TITLE
Nested Containers Not Finishing?

### DIFF
--- a/test/Resolver.finish.js
+++ b/test/Resolver.finish.js
@@ -1,3 +1,4 @@
+import assert from "assert";
 import React from "react";
 import { Resolver } from "../dist";
 
@@ -44,8 +45,8 @@ const BarContainer = Resolver.createContainer(Bar, {
 describe("Resolver", function() {
   describe(".finish", function() {
     it("should finish", function(done) {
-      Resolver.renderToString(<BarContainer />).then(markup => {
-        console.log(markup);
+      Resolver.renderToStaticMarkup(<BarContainer />).then(markup => {
+        assert.equal(markup, "<h1>Foo</h1>");
       }).then(done).catch(done);
     });
   });

--- a/test/Resolver.finish.js
+++ b/test/Resolver.finish.js
@@ -1,0 +1,52 @@
+import React from "react";
+import { Resolver } from "../dist";
+
+class Foo extends React.Component {
+  render() {
+    console.log("render Foo");
+    return (
+      <h1>Foo</h1>
+    );
+  }
+}
+
+Foo.displayName = "Foo";
+
+const FooContainer = Resolver.createContainer(Foo, {
+  resolve: {
+    foo: function() {
+      console.log("foo resolve");
+      return "foo";
+    }
+  }
+});
+
+class Bar extends React.Component {
+  render() {
+    console.log("render Bar");
+    return (
+      <FooContainer />
+    );
+  }
+}
+
+Bar.displayName = "Bar";
+
+const BarContainer = Resolver.createContainer(Bar, {
+  resolve: {
+    bar: function() {
+      console.log("bar resolve");
+      return "bar";
+    }
+  }
+});
+
+describe("Resolver", function() {
+  describe(".finish", function() {
+    it("should finish", function(done) {
+      Resolver.renderToString(<BarContainer />).then(markup => {
+        console.log(markup);
+      }).then(done).catch(done);
+    });
+  });
+});


### PR DESCRIPTION
On an internal project, @willrstern found this peculiar bug:

```js
import React from "react";
import { Resolver } from "react-resolver";

class Foo extends React.Component {
  render() {
    console.log("render Foo");
    return (
      <h1>Foo</h1>
    );
  }
}

Foo.displayName = "Foo";

const FooContainer = Resolver.createContainer(Foo, {
  resolve: {
    foo: function() {
      console.log("foo resolve");
      return "foo";
    }
  }
});

class Bar extends React.Component {
  render() {
    console.log("render Bar");
    return (
      <FooContainer />
    );
  }
}

Bar.displayName = "Bar";

const BarContainer = Resolver.createContainer(Bar, {
  resolve: {
    bar: function() {
      console.log("bar resolve");
      return "bar";
    }
  }
});

export const register = function(server, options, next) {
  server.route({
    method: "GET",
    path: "/{p*}",
    handler: function(request, reply) {
      Resolver.renderToString(<BarContainer />).then((markup) => {
        console.log("render view", markup);
        reply(markup);
      });
    },
  });

  next();
};

register.attributes = { name: "View" };
```

The resolver never seems to `finish()`, so `markup` is never sent.