### PR TITLE
Fix HistoryLocation in React v0.13 Example

### DIFF
--- a/examples/react-v0.13/README.md
+++ b/examples/react-v0.13/README.md
@@ -1,0 +1,23 @@
+# React Resolver - React v0.13 Example
+
+
+### Technologies
+
+- `express` (v4.13.3)
+- `react` (v0.13.3)
+- `react-router` (v0.13.3)
+
+
+### Usage
+
+Development:
+
+```shell
+$ npm start
+```
+
+Production:
+
+```shell
+$ NODE_ENV=production npm start
+```

--- a/examples/react-v0.13/package.json
+++ b/examples/react-v0.13/package.json
@@ -1,10 +1,13 @@
 {
   "private": true,
   "scripts": {
+    "build": "webpack",
+    "clean": "rm -rf dist",
     "preinstall": "rm -rf ./node_modules/react-resolver",
-    "postinstall": "cp -r ../../dist node_modules/react-resolver",
-    "start": "webpack-dev-server --content-base ./public",
-    "watch": "node watch"
+    "postinstall": "cp -r ../../src node_modules/react-resolver",
+    "start": "npm install; if [[ ${NODE_ENV} == \"production\" ]]; then npm run start:prod; else npm run start:dev; fi",
+    "start:dev": "npm run clean && node watch",
+    "start:prod": "npm run clean && npm run build && node src/server"
   },
   "dependencies": {
     "axios": "0.5.4",

--- a/examples/react-v0.13/src/app.js
+++ b/examples/react-v0.13/src/app.js
@@ -1,4 +1,5 @@
 import express from "express";
+import path from "path";
 import React from "react";
 import { Resolver } from "react-resolver";
 import Router from "react-router";
@@ -8,7 +9,7 @@ import routes from "./routes";
 
 export default express()
   // Serve minified assets
-  .use(express.static("../dist"))
+  .use(express.static(path.join(__dirname, "../dist")))
 
   // Let React handle all routes
   .get("*", function(req, res) {

--- a/examples/react-v0.13/src/app.js
+++ b/examples/react-v0.13/src/app.js
@@ -1,0 +1,53 @@
+import express from "express";
+import React from "react";
+import { Resolver } from "react-resolver";
+import Router from "react-router";
+import ServerLocation from "react-router-server-location";
+
+import routes from "./routes";
+
+export default express()
+  // Serve minified assets
+  .use(express.static("../dist"))
+
+  // Let React handle all routes
+  .get("*", function(req, res) {
+    const location = new ServerLocation(req, res);
+
+    Router.create({ location, routes }).run(function(Handler, state) {
+      // Redirect any unknown to home
+      if (!state.routes.length) {
+        return res.redirect("/");
+      }
+
+      const notFound = state.routes.filter(({ name }) => name === "404").length;
+
+      Resolver
+        .resolve(() => <Handler {...state} />)
+        .then(({ Resolved, data }) => {
+          res
+            .status(notFound ? 404 : 200)
+            .send(`
+              <!DOCTYPE html>
+              <html lang="en">
+              <head>
+                <meta charset="UTF-8">
+                <title>Stargazers Demo – React Resolver</title>
+                <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
+              </head>
+              <body>
+                <div id="app">${React.renderToString(<Resolved />)}</div>
+
+                <script src="/client.min.js"></script>
+              </body>
+              </html>
+            `)
+          ;
+        })
+        .catch((error) => {
+          res.status(500).send(error);
+        })
+      ;
+    });
+  })
+;

--- a/examples/react-v0.13/src/app.js
+++ b/examples/react-v0.13/src/app.js
@@ -39,6 +39,7 @@ export default express()
               <body>
                 <div id="app">${React.renderToString(<Resolved />)}</div>
 
+                <script>window.__REACT_RESOLVER_PAYLOAD__ = ${JSON.stringify(data)}</script>
                 <script src="/client.min.js"></script>
               </body>
               </html>

--- a/examples/react-v0.13/src/client.js
+++ b/examples/react-v0.13/src/client.js
@@ -7,6 +7,6 @@ import routes from "./routes";
 
 ES6Promise.polyfill();
 
-Router.run(routes, Router.RefreshLocation, (Root) => {
+Router.run(routes, Router.HistoryLocation, (Root) => {
   Resolver.render(() => <Root />, document.getElementById("app"));
 });

--- a/examples/react-v0.13/src/server.js
+++ b/examples/react-v0.13/src/server.js
@@ -1,54 +1,7 @@
-import express from "express";
-import React from "react";
-import { Resolver } from "react-resolver";
-import Router from "react-router";
-import ServerLocation from "react-router-server-location";
+require("babel/register")({ only: /src|react-resolver/ });
 
-import routes from "./routes";
+var app = require("./app");
 
-express()
-  // Let React handle all routes
-  .get("*", function(req, res) {
-    const location = new ServerLocation(req, res);
-
-    Router.create({ location, routes }).run(function(Handler, state) {
-      // Redirect any unknown to home
-      if (!state.routes.length) {
-        return res.redirect("/");
-      }
-
-      const notFound = state.routes.filter(({ name }) => name === "404").length;
-
-      Resolver
-        .resolve(() => <Handler {...state} />)
-        .then(({ Resolved, data }) => {
-          res
-            .status(notFound ? 404 : 200)
-            .send(`
-              <!DOCTYPE html>
-              <html lang="en">
-              <head>
-                <meta charset="UTF-8">
-                <title>Stargazers Demo – React Resolver</title>
-                <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
-              </head>
-              <body>
-                <div id="app">${React.renderToString(<Resolved />)}</div>
-
-                <script src="/client.min.js" async defer></script>
-                <script>window.__REACT_RESOLVER_PAYLOAD__ = ${JSON.stringify(data)}</script>
-              </body>
-              </html>
-            `)
-          ;
-        })
-        .catch((error) => {
-          res.status(500).send(error);
-        })
-      ;
-    });
-  })
-  .listen(3000, function() {
-    console.info("✅  Node server started at http://localhost:3000/");
-  })
-;
+app.listen(3000, function() {
+  console.info("✅  Node server started at http://localhost:3000/");
+});

--- a/examples/react-v0.13/watch.js
+++ b/examples/react-v0.13/watch.js
@@ -1,5 +1,3 @@
-require("babel/register");
-
 var config = require("./webpack.config");
 var piping = require("piping")({ hook: true });
 var webpack = require("webpack");

--- a/examples/react-v0.13/watch.js
+++ b/examples/react-v0.13/watch.js
@@ -5,6 +5,22 @@ var piping = require("piping")({ hook: true });
 var webpack = require("webpack");
 var WebpackDevServer = require("webpack-dev-server");
 
+config.debug = true;
+config.devtool = "#eval-source-map";
+
+config.entry.client.unshift(
+  "webpack-dev-server/client?http://localhost:8080",
+  "webpack/hot/only-dev-server"
+);
+
+config.plugins.unshift(
+  // Wrap builds with HMR
+  new webpack.HotModuleReplacementPlugin(),
+
+  // Prevent errors from causing a reload
+  new webpack.NoErrorsPlugin()
+);
+
 if (piping) {
   require("./src/server");
 } else {

--- a/examples/react-v0.13/webpack.config.js
+++ b/examples/react-v0.13/webpack.config.js
@@ -1,15 +1,8 @@
 var path = require("path");
-var webpack = require("webpack");
 
 module.exports = {
-  debug: true,
-
-  devtool: "#eval-source-map",
-
   entry: {
     client: [
-      "webpack-dev-server/client?http://localhost:8080",
-      "webpack/hot/only-dev-server",
       path.join(__dirname, "src/client.js"),
     ],
   },
@@ -20,6 +13,7 @@ module.exports = {
         test: /\.js$/,
         include: [
           path.join(__dirname, "src"),
+          path.join(__dirname, "node_modules/react-resolver"),
         ],
         loaders: ["babel"],
       },
@@ -32,17 +26,11 @@ module.exports = {
     filename: "[name].min.js",
     hotUpdateChunkFilename: "update/[hash]/[id].update.js",
     hotUpdateMainFilename: "update/[hash]/update.json",
-    path: path.join(__dirname, "public"),
+    path: path.join(__dirname, "dist"),
     publicPath: "http://localhost:8080/",
   },
 
-  plugins: [
-    // Wrap builds with HMR
-    new webpack.HotModuleReplacementPlugin(),
-
-    // Prevent errors from causing a reload
-    new webpack.NoErrorsPlugin(),
-  ],
+  plugins: [],
 
   target: "web",
 };

--- a/examples/react-v0.14/README.md
+++ b/examples/react-v0.14/README.md
@@ -1,0 +1,24 @@
+# React Resolver - React v0.14 Example
+
+
+### Technologies
+
+- `express` (v4.13.3)
+- `react` (v0.14.0-beta3)
+- `react-dom` (v0.14.0-beta3)
+- `react-router` (v1.0.0-beta3)
+
+
+### Usage
+
+Development:
+
+```shell
+$ npm start
+```
+
+Production:
+
+```shell
+$ NODE_ENV=production npm start
+```

--- a/examples/react-v0.14/package.json
+++ b/examples/react-v0.14/package.json
@@ -1,10 +1,13 @@
 {
   "private": true,
   "scripts": {
+    "build": "webpack",
+    "clean": "rm -rf dist",
     "preinstall": "rm -rf ./node_modules/react-resolver",
-    "postinstall": "cp -r ../../dist node_modules/react-resolver",
-    "start": "webpack-dev-server --content-base ./public",
-    "watch": "node watch"
+    "postinstall": "cp -r ../../src node_modules/react-resolver",
+    "start": "npm install; if [[ ${NODE_ENV} == \"production\" ]]; then npm run start:prod; else npm run start:dev; fi",
+    "start:dev": "npm run clean && node watch",
+    "start:prod": "npm run clean && npm run build && node src/server"
   },
   "dependencies": {
     "axios": "0.5.4",

--- a/examples/react-v0.14/src/app.js
+++ b/examples/react-v0.14/src/app.js
@@ -1,0 +1,49 @@
+import express from "express";
+import Location from "react-router/lib/Location";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { Resolver } from "react-resolver";
+import Router from "react-router";
+
+import routes from "./routes";
+
+export default express()
+  // Let React handle all routes
+  .get("*", function(req, res) {
+    const location = new Location(req.path, req.query);
+
+    Router.run(routes, location, (error, state, transition) => {
+      if (error) {
+        return res.status(500).send(error);
+      }
+
+      Resolver
+        .resolve(() => <Router {...state} />)
+        .then(({ Resolved, data }) => {
+          res
+            .status(200)
+            .send(`
+              <!DOCTYPE html>
+              <html lang="en">
+              <head>
+                <meta charset="UTF-8">
+                <title>Stargazers Demo – React Resolver</title>
+                <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
+              </head>
+              <body>
+                <div id="app">${renderToString(<Resolved />)}</div>
+
+                <script>window.__REACT_RESOLVER_PAYLOAD__ = ${JSON.stringify(data)}</script>
+                <script src="/client.min.js"></script>
+              </body>
+              </html>
+            `)
+          ;
+        })
+        .catch((error) => {
+          res.status(500).send(error);
+        })
+      ;
+    });
+  })
+;

--- a/examples/react-v0.14/src/server.js
+++ b/examples/react-v0.14/src/server.js
@@ -1,52 +1,7 @@
-import express from "express";
-import Location from "react-router/lib/Location";
-import React from "react";
-import { renderToString } from "react-dom/server";
-import { Resolver } from "react-resolver";
-import Router from "react-router";
+require("babel/register")({ only: /src|react-resolver/ });
 
-import routes from "./routes";
+var app = require("./app");
 
-express()
-  // Let React handle all routes
-  .get("*", function(req, res) {
-    const location = new Location(req.path, req.query);
-
-    Router.run(routes, location, (error, state, transition) => {
-      if (error) {
-        return res.status(500).send(error);
-      }
-
-      Resolver
-        .resolve(() => <Router {...state} />)
-        .then(({ Resolved, data }) => {
-          res
-            .status(200)
-            .send(`
-              <!DOCTYPE html>
-              <html lang="en">
-              <head>
-                <meta charset="UTF-8">
-                <title>Stargazers Demo – React Resolver</title>
-                <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
-              </head>
-              <body>
-                <div id="app">${renderToString(<Resolved />)}</div>
-
-                <script src="/client.min.js" async defer></script>
-                <script>window.__REACT_RESOLVER_PAYLOAD__ = ${JSON.stringify(data)}</script>
-              </body>
-              </html>
-            `)
-          ;
-        })
-        .catch((error) => {
-          res.status(500).send(error);
-        })
-      ;
-    });
-  })
-  .listen(3000, function() {
-    console.info("✅  Node server started at http://localhost:3000/");
-  })
-;
+app.listen(3000, function() {
+  console.info("✅  Node server started at http://localhost:3000/");
+});

--- a/examples/react-v0.14/watch.js
+++ b/examples/react-v0.14/watch.js
@@ -1,9 +1,23 @@
-require("babel/register");
-
 var config = require("./webpack.config");
 var piping = require("piping")({ hook: true });
 var webpack = require("webpack");
 var WebpackDevServer = require("webpack-dev-server");
+
+config.debug = true;
+config.devtool = "#eval-source-map";
+
+config.entry.client.unshift(
+  "webpack-dev-server/client?http://localhost:8080",
+  "webpack/hot/only-dev-server"
+);
+
+config.plugins.unshift(
+  // Wrap builds with HMR
+  new webpack.HotModuleReplacementPlugin(),
+
+  // Prevent errors from causing a reload
+  new webpack.NoErrorsPlugin()
+);
 
 if (piping) {
   require("./src/server");

--- a/examples/react-v0.14/webpack.config.js
+++ b/examples/react-v0.14/webpack.config.js
@@ -1,15 +1,8 @@
 var path = require("path");
-var webpack = require("webpack");
 
 module.exports = {
-  debug: true,
-
-  devtool: "#eval-source-map",
-
   entry: {
     client: [
-      "webpack-dev-server/client?http://localhost:8080",
-      "webpack/hot/only-dev-server",
       path.join(__dirname, "src/client.js"),
     ],
   },
@@ -20,6 +13,7 @@ module.exports = {
         test: /\.js$/,
         include: [
           path.join(__dirname, "src"),
+          path.join(__dirname, "node_modules/react-resolver"),
         ],
         loaders: ["babel"],
       },
@@ -32,17 +26,11 @@ module.exports = {
     filename: "[name].min.js",
     hotUpdateChunkFilename: "update/[hash]/[id].update.js",
     hotUpdateMainFilename: "update/[hash]/update.json",
-    path: path.join(__dirname, "public"),
+    path: path.join(__dirname, "dist"),
     publicPath: "http://localhost:8080/",
   },
 
-  plugins: [
-    // Wrap builds with HMR
-    new webpack.HotModuleReplacementPlugin(),
-
-    // Prevent errors from causing a reload
-    new webpack.NoErrorsPlugin(),
-  ],
+  plugins: [],
 
   target: "web",
 };

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -6,6 +6,7 @@ const ID = "ReactResolver.ID";
 const CHILDREN = "ReactResolver.CHILDREN";
 const HAS_RESOLVED = "ReactResolver.HAS_RESOLVED";
 const IS_CLIENT = "ReactResolver.IS_CLIENT";
+const PAYLOAD = "__REACT_RESOLVER_PAYLOAD__";
 
 export default class Resolver extends React.Component {
   static childContextTypes = {
@@ -29,25 +30,23 @@ export default class Resolver extends React.Component {
     resolve: React.PropTypes.object,
   }
 
-  static render = function(render, node) {
-    const initialData = window.__REACT_RESOLVER_PAYLOAD__;
-
+  static render = function(render, node, data = window[PAYLOAD]) {
     // Server-rendered output, but missing payload
-    if (!initialData && node.innerHTML) {
-      return Resolver.resolve(render).then(({ Resolved }) => {
-        // @TODO - Use react-dom.render
-        React.render(<Resolved />, node);
-      });
+    if (node.innerHTML && !data) {
+      return Resolver
+        .resolve(render)
+        .then(({ data }) => Resolver.render(render, node, data))
+      ;
     }
 
     // @TODO - Use react-dom.render
     React.render((
-      <Resolver data={initialData}>
+      <Resolver data={data}>
         {render}
       </Resolver>
     ), node);
 
-    delete window.__REACT_RESOLVER_PAYLOAD__;
+    delete window[PAYLOAD];
   }
 
   static resolve = function(render, initialData = {}) {


### PR DESCRIPTION
Hi!

Using HistoryLocation, instead of RefreshLocation as used in the examples, I'm only able to navigate via react-router (both Link component and transitionTo('<page>')) once pr. page load. I've tried to fiddle around with both the source for react-router and react-resolver, but without success. The URL changes, but the 

I've reduced my issue down to [this repo](https://github.com/ostrgard/react-router-resolver-issue), which can be run with `npm install` and `npm run watch`. If you uncomment 11th line and comment the 10th line in `src/client.js`, you'll notice that routing works, but obviously serverside rendering does not. This leads me to think this could be a Resolver problem.

Anyone having the same issue? Have I done something wrong? I've tried to implement Resolver as per the examples as close as possible.