### PR TITLE
[HOLD] React Router v1 messes up with missing payload

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -31,17 +31,6 @@ export default class Resolver extends React.Component {
   }
 
   static render = function(render, node, data = window[PAYLOAD]) {
-    // Server-rendered output, but missing payload
-    if (node.innerHTML && !data) {
-      return Resolver
-        .resolve(render)
-        .then(({ Resolved }) => {
-          // @TODO - Use react-dom.render
-          React.render(<Resolved />, node);
-        })
-      ;
-    }
-
     // @TODO - Use react-dom.render
     React.render((
       <Resolver data={data}>

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -37,8 +37,6 @@ export default class Resolver extends React.Component {
         {render}
       </Resolver>
     ), node);
-
-    delete window[PAYLOAD];
   }
 
   static resolve = function(render, initialData = {}) {


### PR DESCRIPTION
Hello. I'm trying to make a simple project with `react-resolver` + `react-router`. But it doesn't work. I've placed it here: https://github.com/alexbyk/react-resolver-example

Could you pls take a look... what am I missing? The simple click action causes an error (without `Resolver` works fine):
`Uncaught TypeError: Cannot read property 'firstChild' of undefined` && `TypeError: deepestAncestor is undefined`
