### PR TITLE
Regression with HistoryLocation in React v0.13 Example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # React Resolver Changelog
 
+### v2.0.5 - (2015-09-07)
+
+- Fix React Router v0.13.3 `HistoryLocation` bug
+  + <https://github.com/ericclemmons/react-resolver/pull/78>
+  + <https://github.com/ericclemmons/react-resolver/issues/75>
+
+
 ### v2.0.4 - (2015-08-25)
 
 - Support _thenables_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-resolver",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Async-rendering & data-fetching for universal React applications",
   "main": "dist/index.js",
   "directories": {

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -33,17 +33,6 @@ export default class Resolver extends React.Component {
   }
 
   static render = function(render, node, data = window[PAYLOAD]) {
-    // Server-rendered output, but missing payload
-    if (node.innerHTML && !data) {
-      return Resolver
-        .resolve(render)
-        .then(({ Resolved }) => {
-          // @TODO - Use react-dom.render
-          React.render(<Resolved />, node);
-        })
-      ;
-    }
-
     // @TODO - Use react-dom.render
     React.render((
       <Resolver data={data}>


### PR DESCRIPTION
First discovered in ericclemmons/react-resolver#77:

> ![example](https://cloud.githubusercontent.com/assets/15182/9560109/a2edece8-4dc9-11e5-98c3-1c9d0973316e.gif)
