### PR TITLE
require babel-core instead of babel in examples 

### DIFF
--- a/examples/react-v0.13/src/server.js
+++ b/examples/react-v0.13/src/server.js
@@ -1,4 +1,4 @@
-require("babel/register")({ only: /src|react-resolver/ });
+require("babel-core/register")({ only: /src|react-resolver/ });
 
 var app = require("./app");
 

--- a/examples/react-v0.14/src/server.js
+++ b/examples/react-v0.14/src/server.js
@@ -1,4 +1,4 @@
-require("babel/register")({ only: /src|react-resolver/ });
+require("babel-core/register")({ only: /src|react-resolver/ });
 
 var app = require("./app");
 


### PR DESCRIPTION
Fix for #77
