### PR TITLE
fix the postversion npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint src test",
     "prepublish": "npm run build",
     "preversion": "npm run clean",
-    "postversion": "git push origin master --tags && npm run docs:publisher",
+    "postversion": "git push origin master --tags && npm run docs:publish",
     "test": "mocha",
     "version": "npm run build"
   },


### PR DESCRIPTION
@ericclemmons this breaking resulted in sort of an unknown state mid-release...I think that the git tag/package.json version is in fine shape, but it looks like there was a gitbooks/doc push that went through. Hopefully a moot point once I merge this and re-version bump.  