### PR TITLE
Adds support for React 15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "test"
   },
   "peerDependencies": {
-    "react": "^0.14.6",
-    "react-dom": "^0.14.6"
+    "react": "^0.14.6 || ^15.0.0-0",
+    "react-dom": "^0.14.6 || ^15.0.0-0"
   },
   "devDependencies": {
     "babel": "5.8.34",
@@ -18,8 +18,8 @@
     "gitbook-plugin-include-highlight": "0.1.0",
     "gitbook-plugin-todo": "0.1.2",
     "mocha": "2.3.4",
-    "react": "^0.14.6",
-    "react-dom": "^0.14.6"
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
   },
   "scripts": {
     "build": "npm run clean && npm run build:docs && npm run build:lib",

--- a/test/resolve.test.js
+++ b/test/resolve.test.js
@@ -1,5 +1,6 @@
 import assert from "assert";
 import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import { resolve, Resolver } from "..";
 
@@ -32,7 +33,7 @@ describe("@resolve", function() {
 
     it("is synchronous", function() {
       assert.equal(
-        React.renderToStaticMarkup(<Test actual="scalar" expected="scalar" />),
+        renderToStaticMarkup(<Test actual="scalar" expected="scalar" />),
         "<pre>scalar</pre>"
       );
     });
@@ -45,8 +46,8 @@ describe("@resolve", function() {
 
     it("is asynchronous", function() {
       assert.equal(
-        React.renderToStaticMarkup(<Test actual={Promise.resolve("promise")} expected="promise" />),
-        "<noscript></noscript>"
+        renderToStaticMarkup(<Test actual={Promise.resolve("promise")} expected="promise" />),
+        ""
       );
     });
   });
@@ -62,8 +63,8 @@ describe("@resolve", function() {
 
     it("is asynchronous", function() {
       assert.equal(
-        React.renderToStaticMarkup(<Test actual={thenable} expected="thenable" />),
-        "<noscript></noscript>"
+        renderToStaticMarkup(<Test actual={thenable} expected="thenable" />),
+        ""
       );
     });
   });


### PR DESCRIPTION
This PR adds support for React 15.

Changes made:
- Updated package.json's `peerDependencies`
- Updated package.json's `devDependencies`
- Updated tests to use `react-dom/server` for `renderToStaticMarkup` instead of `react`.
- The main `Resolver.js` code seems to already be using `react-dom/server` so no changes needed to be made there

Testing:
- All tests pass via `npm run test`
- Unable to run linting via `npm run lint` because the peerDependencies of `eslint-config-future` are not installed (resulting in `eslint-config-future@2.1.1 requires a peer of babel-eslint@3.x but none was installed` errors, etc..). And I was unable to manually install the required dependencies because `eslint-config-future` wants `babel-eslint@3.1.x` but that version of `babel-eslint` is broken due to this bug: https://github.com/babel/babel-eslint/issues/243 No idea of linting will pass as a result of this.

