### PR TITLE
Remove promise duplication.

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -48,7 +48,10 @@ export default class Resolver extends React.Component {
     const queue = [];
 
     renderToStaticMarkup(
-      <Resolver data={initialData} onResolve={(promise) => queue.push(promise)}>
+      <Resolver data={initialData} onResolve={((promise) => {
+        queue.push(promise);
+        return Promise.resolve(true); 
+      })}>
         {render}
       </Resolver>
     );
@@ -211,9 +214,11 @@ export default class Resolver extends React.Component {
 
   onResolve(state) {
     if (this.props.onResolve) {
-      this.props.onResolve(state);
+      return this.props.onResolve(state);
     } else if (this.context.resolver) {
-      this.context.resolver.onResolve(state);
+      return this.context.resolver.onResolve(state);
+    } else {
+      return state;
     }
   }
 
@@ -244,7 +249,7 @@ export default class Resolver extends React.Component {
 
     const promises = pending.map(({ promise }) => promise);
 
-    const resolving = Promise.all(promises).then(values => {
+    var resolving = Promise.all(promises).then(values => {
       const id = this[ID];
       const resolved = values.reduce((resolved, value, i) => {
         const { name } = pending[i];
@@ -258,7 +263,7 @@ export default class Resolver extends React.Component {
     });
 
     // Resolve listeners get the current ID + resolved
-    this.onResolve(resolving);
+    resolving = this.onResolve(resolving);
 
     // Update current component with new data (on client)
     resolving.then(({ resolved }) => {

--- a/src/client.js
+++ b/src/client.js
@@ -35,6 +35,7 @@ export default function client(Loader) {
 
       enqueue(promise) {
         this.queue.push(promise);
+        return promise;
       }
 
       render() {


### PR DESCRIPTION
Fixes #116 

It may not seems obvious with all stuff happening with promises in `react-router` but methods do not mutate those.
e.g.
```
let a = new Promise(...)
let b = a.then(...)
let c = a.then(...)
```
`b` and `c` are completely different. And if the exception will be thrown in `a` there will be 2 unhanded ones.

We should either always handle promises without breaking the chain, or wrap every split with a catch block. This PR implements the 1st option.