### PR TITLE
Accept props that are empty (For Redux mapStateToProps)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _book
 dist
 node_modules
 npm-debug.log
+.idea

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -149,7 +149,7 @@ export default class Resolver extends React.Component {
 
     Object.keys(resolve).forEach(name => {
       // Ignore existing supplied props or existing resolved values
-      if (this.shouldIgnoreProp(props, name) && !nextState.resolved.hasOwnProperty(name)) {
+      if (!nextState.resolved.hasOwnProperty(name)) {
         const factory = resolve[name];
         const value = factory(props);
         const isPromise = (
@@ -176,10 +176,6 @@ export default class Resolver extends React.Component {
     });
 
     return nextState;
-  }
-
-  shouldIgnoreProp(props, name) {
-    return !props.hasOwnProperty(name) || !props[name] || !props[name].length
   }
 
   generateId() {

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -149,7 +149,7 @@ export default class Resolver extends React.Component {
 
     Object.keys(resolve).forEach(name => {
       // Ignore existing supplied props or existing resolved values
-      if (!props.hasOwnProperty(name) && !nextState.resolved.hasOwnProperty(name)) {
+      if (this.shouldIgnoreProp(props, name) && !nextState.resolved.hasOwnProperty(name)) {
         const factory = resolve[name];
         const value = factory(props);
         const isPromise = (
@@ -176,6 +176,10 @@ export default class Resolver extends React.Component {
     });
 
     return nextState;
+  }
+
+  shouldIgnoreProp(props, name) {
+    return !props.hasOwnProperty(name) || !props[name] || !props[name].length
   }
 
   generateId() {


### PR DESCRIPTION
This way it does not conflict with mapStateToProps when the prop is still empty.