### PR TITLE
added renderBeforeResolved option

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -32,6 +32,7 @@ export default class Resolver extends React.Component {
     data: React.PropTypes.object.isRequired,
     props: React.PropTypes.object,
     resolve: React.PropTypes.object,
+    renderBeforeResolved: React.PropTypes.bool
   }
 
   static render = function(render, node, data = window[PAYLOAD]) {
@@ -50,7 +51,7 @@ export default class Resolver extends React.Component {
     renderToStaticMarkup(
       <Resolver data={initialData} onResolve={((promise) => {
         queue.push(promise);
-        return Promise.resolve(true); 
+        return Promise.resolve(true);
       })}>
         {render}
       </Resolver>
@@ -224,7 +225,7 @@ export default class Resolver extends React.Component {
 
   render() {
     // Avoid rendering until ready
-    if (!this[HAS_RESOLVED]) {
+    if (!this.props.renderBeforeResolved && !this[HAS_RESOLVED]) {
       return false;
     }
 

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -6,8 +6,12 @@ const capitalize = (word) => {
   return word.replace(/^./, (letter) => letter.toUpperCase());
 };
 
-export default function resolve(prop, promise) {
-  const asyncProps = (arguments.length === 1) ? prop : { [prop]: promise };
+export default function resolve(prop, promise, opts) {
+  if (!opts && typeof promise === 'object') {
+    opts = promise;
+    promise = null;
+  }
+  const asyncProps = !promise ? prop : { [prop]: promise };
   const asyncNames = Object.keys(asyncProps).map(capitalize).join("");
 
   return function resolveDecorator(Component) {
@@ -16,7 +20,7 @@ export default function resolve(prop, promise) {
 
       render() {
         return (
-          <Resolver props={this.props} resolve={asyncProps}>
+          <Resolver props={this.props} resolve={asyncProps} {...opts}>
             {(resolved) => <Component {...this.props} {...resolved} />}
           </Resolver>
         );


### PR DESCRIPTION
I love this library, but I create my components to function with or without resolved data, so I don't need Loader components, and I'd rather just render the component (client-side) while its promises resolve. This commit enables that.