### PR TITLE
change React.PropTypes to prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gitbook-plugin-prism": "^1.1.0",
     "gitbook-plugin-todo": "0.1.2",
     "mocha": "2.3.4",
+    "prop-types": "^15.5.8",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 import {renderToStaticMarkup} from "react-dom/server";
@@ -12,11 +13,11 @@ const PAYLOAD = "__REACT_RESOLVER_PAYLOAD__";
 
 export default class Resolver extends React.Component {
   static childContextTypes = {
-    resolver: React.PropTypes.instanceOf(Resolver),
+    resolver: PropTypes.instanceOf(Resolver),
   }
 
   static contextTypes = {
-    resolver: React.PropTypes.instanceOf(Resolver),
+    resolver: PropTypes.instanceOf(Resolver),
   }
 
   static defaultProps = {
@@ -28,10 +29,10 @@ export default class Resolver extends React.Component {
   static displayName = "Resolver"
 
   static propTypes = {
-    children: React.PropTypes.func.isRequired,
-    data: React.PropTypes.object.isRequired,
-    props: React.PropTypes.object,
-    resolve: React.PropTypes.object,
+    children: PropTypes.func.isRequired,
+    data: PropTypes.object.isRequired,
+    props: PropTypes.object,
+    resolve: PropTypes.object,
   }
 
   static render = function(render, node, data = window[PAYLOAD]) {

--- a/src/client.js
+++ b/src/client.js
@@ -1,18 +1,19 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import Resolver from "./Resolver";
 
 export default function client(Loader) {
   return function clientDecorator(Component) {
-    return class ClientResolver extends React.Component {
+    return class ClientResolver extends Component {
       static displayName = `ClientResolver`
 
       static childContextTypes = {
-        resolver: React.PropTypes.instanceOf(Resolver),
+        resolver: PropTypes.instanceOf(Resolver),
       }
 
       static contextTypes = {
-        resolver: React.PropTypes.instanceOf(Resolver),
+        resolver: PropTypes.instanceOf(Resolver),
       }
 
       constructor(props, context) {

--- a/src/context.js
+++ b/src/context.js
@@ -1,6 +1,7 @@
+import PropTypes from "prop-types";
 import React from "react";
 
-export default function context(name, type = React.PropTypes.any.isRequired) {
+export default function context(name, type = PropTypes.any.isRequired) {
   return function contextDecorator(Component) {
     class ContextDecorator extends React.Component {
       static contextTypes = {


### PR DESCRIPTION
React 15.5.0 now displays a warning when using `React.PropTypes`. This PR changes every occurence of `React.PropTypes` to the new `PropTypes` from [prop-types](https://github.com/reactjs/prop-types) package